### PR TITLE
docs: hand off SHAFT MCP to SHAFT_ENGINE

### DIFF
--- a/.github/workflows/migrate-ghcr-to-shaft-engine.yml
+++ b/.github/workflows/migrate-ghcr-to-shaft-engine.yml
@@ -1,0 +1,45 @@
+name: Migrate GHCR package to SHAFT_ENGINE
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  migrate:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout canonical SHAFT source
+        uses: actions/checkout@v6
+        with:
+          repository: ShaftHQ/SHAFT_ENGINE
+          ref: 10.2.20260612
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push canonical OCI image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: shaft-mcp/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/shafthq/shaft-mcp:10.2.20260612
+            ghcr.io/shafthq/shaft-mcp:latest
+          labels: |
+            io.modelcontextprotocol.server.name=io.github.ShaftHQ/shaft-mcp
+            org.opencontainers.image.source=https://github.com/ShaftHQ/SHAFT_ENGINE
+            org.opencontainers.image.description=SHAFT MCP server for browser and test automation
+            org.opencontainers.image.licenses=MIT
+
+      - name: Verify published tags
+        run: |
+          docker buildx imagetools inspect ghcr.io/shafthq/shaft-mcp:10.2.20260612
+          docker buildx imagetools inspect ghcr.io/shafthq/shaft-mcp:latest

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,13 @@
+> [!IMPORTANT]
+> This repository is historical and has moved to
+> [`ShaftHQ/SHAFT_ENGINE`](https://github.com/ShaftHQ/SHAFT_ENGINE/tree/main/shaft-mcp).
+> Use the maintained [SHAFT MCP guide](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/docs/SHAFT_MCP.md),
+> [SHAFT Pilot guide](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/docs/SHAFT_PILOT.md),
+> and [usage examples](https://github.com/ShaftHQ/SHAFT_ENGINE/tree/main/docs/examples/shaft-pilot).
+> The current release is
+> [`10.2.20260612`](https://github.com/ShaftHQ/SHAFT_ENGINE/releases/tag/10.2.20260612).
+> Existing issues and releases remain available here as a read-only historical record.
+
 <h1>
 <picture>
   <!-- User prefers light mode: -->


### PR DESCRIPTION
## Summary
- mark this repository as historical and link maintained SHAFT MCP/Pilot documentation and examples
- add a one-time manual workflow that transfers the existing GHCR package to ShaftHQ/SHAFT_ENGINE using OCI source metadata

## Sequence
1. Merge this PR.
2. Run the migration workflow once.
3. Prove SHAFT_ENGINE can publish the package independently.
4. Disable workflows and archive this repository.

Related to ShaftHQ/SHAFT_ENGINE#2858